### PR TITLE
Add missing comma to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pytest-shelltest',
-    description='Doctest for command line code examples.'
+    description='Doctest for command line code examples.',
     author='Oliver Sanders',
     author_email='.',
     version='0.1',


### PR DESCRIPTION
PyCharm was not happy with `setup.py`. Had a look, and it looks like it's missing one comma in `setup.py`.

After that, `python setup.py -e .` worked like a charm. Did a quick test via command line:

```bash
$ pytest README.md 
======================================================================================== test session starts ========================================================================================
platform linux -- Python 3.7.2, pytest-3.8.0, py-1.6.0, pluggy-0.7.1 -- /home/kinow/Development/python/anaconda3/bin/python
cachedir: .pytest_cache
rootdir: /home/kinow/Development/python/workspace/isodatetime, inifile: pytest.ini
plugins: remotedata-0.3.0, openfiles-0.3.0, env-0.6.2, doctestplus-0.1.3, cov-2.6.0, arraydiff-0.2, shelltest-0.1
collected 1 item                                                                                                                                                                                    

README.md::README.md PASSED

===================================================================================== 1 passed in 0.03 seconds ======================================================================================
```

And also worked in the IDE when I clicked on the project and asked it to run all the tests (see `README.md` in the list...).

![image](https://user-images.githubusercontent.com/304786/51423199-26163980-1c21-11e9-8d42-93b12a478b3a.png)

Have to uninstall it as I have other projects that use `$` and am afraid it could cause issues. However, will have it installed in a virtualenv for `isodatetime` :tada: !

Great idea!
